### PR TITLE
Returns -Xmx and -Xms in bytes

### DIFF
--- a/src/types/fileInfo.ts
+++ b/src/types/fileInfo.ts
@@ -77,7 +77,10 @@ export class MinecraftFileInfo implements FileInfo {
   width?: string;
 
   // System attributes
-  allocatedMemory?: string;
+  /** -Xmx Java flag in bytes */
+  xmx?: number;
+  /** -Xms Java flag in bytes */
+  xms?: number;
   cpu?: string;
   java?: string;
   os?: string;

--- a/tests/parsers/standardLog/parseSystem.test.ts
+++ b/tests/parsers/standardLog/parseSystem.test.ts
@@ -7,7 +7,8 @@ describe('Standard log system parser', () => {
     const system = parseSystem(fileLines);
 
     expect(system).toEqual({
-      allocatedMemory: '-Xmx8192m, -Xms256m',
+      xmx: 8388608000,
+      xms: 262144000,
       java: '1.8.0.51',
       os: 'Windows 10:amd64:10.0',
     });
@@ -18,7 +19,8 @@ describe('Standard log system parser', () => {
     const system = parseSystem(fileLines);
 
     expect(system).toEqual({
-      allocatedMemory: '-Xmx8192m, -Xms256m',
+      xmx: 8388608000,
+      xms: 262144000,
       java: '1.8.0.51',
       os: 'Windows 10:amd64:10.0',
     });


### PR DESCRIPTION
Return memory flags in bytes instead of "8192m" format